### PR TITLE
Connected new components with General GeneralTab

### DIFF
--- a/src/Data.js
+++ b/src/Data.js
@@ -39,11 +39,11 @@ const preparePokemonObject = (jsons) => {
   return {
     id: jsons[0].id,
     name: jsons[0].name.charAt(0).toUpperCase() + jsons[0].name.slice(1),
-    height: Number(jsons[0].height) / 10 + ' m',
-    weight: Number(jsons[0].weight) / 10 + ' kg',
+    height: Number(jsons[0].height) / 10,
+    weight: Number(jsons[0].weight) / 10,
     sprite: jsons[0].sprites.other['official-artwork'].front_default,
     types: jsons[0].types.map((i) => i.type).map((i) => i.name),
-    //"stats": jsons[0].stats.map(i => [i.stat.name, i.base_stat]),
+    stats: jsons[0].stats.map((i) => [i.stat.name, i.base_stat]),
     //"moves": jsons[0].moves, // This one needs a lot of reshaping, maybe it should be in another function?
     color: jsons[1].color.name,
     //"generation": jsons[1].generation.name,

--- a/src/components/DetailsAppBar.js
+++ b/src/components/DetailsAppBar.js
@@ -2,9 +2,11 @@ import React from 'react';
 import { setStatusBarBackgroundColor } from 'expo-status-bar';
 import { useTheme, Surface, Button } from 'react-native-paper';
 import { Image, StyleSheet, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 
 export default function DetailsAppBar({ color, sprite }) {
   const colors = useTheme().colors;
+  const navigation = useNavigation();
 
   // For now it is the same color as whole component, but later it will be a little bit darker:
   setStatusBarBackgroundColor(colors.pokemon.background[color]);
@@ -16,7 +18,7 @@ export default function DetailsAppBar({ color, sprite }) {
           icon='arrow-left'
           color={colors.arrowAndTitle}
           labelStyle={styles.buttonContent}
-          onPress={() => {}}
+          onPress={() => navigation.navigate('Home')}
         >
           Pokedex
         </Button>

--- a/src/components/PokemonCard.js
+++ b/src/components/PokemonCard.js
@@ -13,7 +13,9 @@ export default function PokemonCard({ onPress, id, color, name, sprite, types })
     <Surface style={[styles.container, { backgroundColor: cardColor }]}>
       <TouchableRipple borderless={true} style={styles.touch} onPress={() => onPress()}>
         <>
-          <Text style={[styles.id, { color: 'black' }]}>{'#' + id}</Text>
+          <Text style={[styles.id, { color: 'black' }]}>
+            {'#' + id.toString().padStart(3, '0')}
+          </Text>
           <MaterialCommunityIcons
             style={styles.favourite}
             name='heart-outline'
@@ -60,7 +62,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 10,
     top: 10,
-    fontSize: 18,
+    fontSize: 15,
   },
   favourite: {
     position: 'absolute',
@@ -79,5 +81,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-around',
     alignContent: 'center',
+    width: '80%',
   },
 });

--- a/src/components/PokemonCard.js
+++ b/src/components/PokemonCard.js
@@ -62,7 +62,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 10,
     top: 10,
-    fontSize: 15,
+    fontSize: 18,
   },
   favourite: {
     position: 'absolute',

--- a/src/components/PokemonGeneralInfo.js
+++ b/src/components/PokemonGeneralInfo.js
@@ -1,41 +1,49 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTheme, Text } from 'react-native-paper';
+import { PokemonDataContext } from '../contexts';
 
 import PokemonType from './PokemonType';
 
-export default function PokemonGeneralInfo({ name, id, weight, height, types }) {
+export default function PokemonGeneralInfo() {
+  const { currentPokemon } = useContext(PokemonDataContext);
   const colors = useTheme().colors;
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.card }]}>
-      <Text style={styles.name}>{name}</Text>
+    <>
+      {currentPokemon ? (
+        <View style={[styles.container, { backgroundColor: colors.card }]}>
+          <Text style={styles.name}>{currentPokemon.name}</Text>
 
-      <Text style={styles.id}>{'#' + id.padStart(3, '0')}</Text>
+          <Text style={styles.id}>{'#' + currentPokemon.id.toString().padStart(3, '0')}</Text>
 
-      <View style={styles.typesContainer}>
-        {types.map((type, index) => (
-          <PokemonType
-            key={index}
-            type={type}
-            containerStyle={styles.typeContainer}
-            textStyle={styles.typeText}
-          />
-        ))}
-      </View>
+          <View style={styles.typesContainer}>
+            {currentPokemon.types.map((type, index) => (
+              <PokemonType
+                key={index}
+                type={type}
+                containerStyle={styles.typeContainer}
+                textStyle={styles.typeText}
+              />
+            ))}
+          </View>
 
-      <View style={styles.infoContainer}>
-        <View style={styles.info}>
-          <Text style={styles.infoText}>Weight</Text>
-          <Text style={styles.infoData}>{weight + ' KG'}</Text>
+          <View style={styles.infoContainer}>
+            <View style={styles.info}>
+              <Text style={styles.infoText}>Weight</Text>
+              <Text style={styles.infoData}>{currentPokemon.weight + ' KG'}</Text>
+            </View>
+
+            <View style={styles.info}>
+              <Text style={styles.infoText}>Height</Text>
+              <Text style={styles.infoData}>{currentPokemon.height + ' M'}</Text>
+            </View>
+          </View>
         </View>
-
-        <View style={styles.info}>
-          <Text style={styles.infoText}>Height</Text>
-          <Text style={styles.infoData}>{height + ' M'}</Text>
-        </View>
-      </View>
-    </View>
+      ) : (
+        <ActivityIndicator animating={true} />
+      )}
+    </>
   );
 }
 

--- a/src/components/PokemonStats.js
+++ b/src/components/PokemonStats.js
@@ -1,25 +1,37 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import { useTheme } from 'react-native-paper';
+import { PokemonDataContext } from '../contexts';
 
 import StatBar from '../components/StatBar';
 
-export default function PokemonStats({ hp, atk, def, satk, sdef, spd }) {
+export default function PokemonStats() {
+  const { currentPokemon } = useContext(PokemonDataContext);
+  //const statsNames = currentPokemon.stats.map(i => i[0]);
+  const statsValues = currentPokemon.stats.map((i) => i[1]);
   const colors = useTheme().colors;
   const stats = colors.pokemon.stats;
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.card }]}>
-      <Text style={styles.header}>Base stats</Text>
-      <StatBar name='HP' value={hp} color={stats.hp} />
-      <StatBar name='ATK' value={atk} color={stats.attack} />
-      <StatBar name='DEF' value={def} color={stats.defense} />
-      <StatBar name='SP ATK' value={satk} color={stats.specialAttack} />
-      <StatBar name='SP DEF' value={sdef} color={stats.specialDefence} />
-      <StatBar name='SPD' value={spd} color={stats.speed} />
+    <>
+      {currentPokemon ? (
+        <View style={[styles.container, { backgroundColor: colors.card }]}>
+          <Text style={styles.header}>Base stats</Text>
+          <StatBar name='HP' value={statsValues[0]} color={stats.hp} />
+          <StatBar name='ATK' value={statsValues[1]} color={stats.attack} />
+          <StatBar name='DEF' value={statsValues[2]} color={stats.defense} />
+          <StatBar name='SP ATK' value={statsValues[3]} color={stats.specialAttack} />
+          <StatBar name='SP DEF' value={statsValues[4]} color={stats.specialDefence} />
+          <StatBar name='SPD' value={statsValues[5]} color={stats.speed} />
 
-      <Text style={styles.total}>{`TOTAL ${hp + atk + def + satk + sdef + spd}`}</Text>
-    </View>
+          <Text style={styles.total}>{`TOTAL ${statsValues.reduce(
+            (result, number) => result + number
+          )}`}</Text>
+        </View>
+      ) : (
+        <ActivityIndicator animating={true} />
+      )}
+    </>
   );
 }
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,5 @@
 export { default as MainAppBar } from './MainAppBar';
 export { default as DetailsAppBar } from './DetailsAppBar';
 export { default as PokemonCard } from './PokemonCard';
+export { default as PokemonGeneralInfo } from './PokemonGeneralInfo';
+export { default as PokemonStats } from './PokemonStats';

--- a/src/screens/details/General.js
+++ b/src/screens/details/General.js
@@ -1,8 +1,8 @@
 import React, { useContext } from 'react';
-import { SafeAreaView, StyleSheet, Text } from 'react-native';
+import { SafeAreaView, StyleSheet, ScrollView } from 'react-native';
 import { ActivityIndicator } from 'react-native-paper';
 
-import { DetailsAppBar } from '../../components';
+import { DetailsAppBar, PokemonGeneralInfo, PokemonStats } from '../../components';
 import { PokemonDataContext } from '../../contexts';
 
 export default function General() {
@@ -13,8 +13,11 @@ export default function General() {
       {currentPokemon ? (
         <>
           <DetailsAppBar color={currentPokemon.color} sprite={currentPokemon.sprite} />
-          <SafeAreaView style={styles.ListContainer}>
-            <Text>[General]</Text>
+          <SafeAreaView style={styles.container}>
+            <ScrollView>
+              <PokemonGeneralInfo style={styles.singleComponent} />
+              <PokemonStats style={styles.singleComponent} />
+            </ScrollView>
           </SafeAreaView>
         </>
       ) : (
@@ -25,9 +28,11 @@ export default function General() {
 }
 
 const styles = StyleSheet.create({
-  ListContainer: {
+  container: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+    marginTop: 10,
+    marginBottom: 10,
   },
 });

--- a/src/screens/details/General.js
+++ b/src/screens/details/General.js
@@ -32,7 +32,6 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    marginTop: 10,
-    marginBottom: 10,
+    marginVertical: 10,
   },
 });


### PR DESCRIPTION
DONE:
- Modified PokemonGeneralInfo and PokemonStats components so now they use the UseContext method instead of arguments to display the data,
- Modified General screen so it displays both of these components in a ScrollView,
- Added possibility to return to Home Screen by clicking the arrow with "Pokedex" title in the left upper corner of the details screen,
- Modified Data.js file to return just numbers of weight and height without any letters + uncommented stats,
- Modified main screen's pokemons' tiles: the id is displayed in format eg. "#001" and the types have some space between them.

TO DO:
- General Screen needs a lot of styling - new components don't fit there well,
- Tabs in Details should have color of pokemon instead of default one,
- Clicking back button should transport into Home screen, not another tab (which happens if we click more than one tab in details screen).

![image](https://user-images.githubusercontent.com/43967269/116995213-1465dc80-acda-11eb-9aaa-57ca6780c50d.png)
![image](https://user-images.githubusercontent.com/43967269/116995352-4119f400-acda-11eb-9b15-2d35bf0054f6.png)